### PR TITLE
fix(builder): added ability to specify a custom error message

### DIFF
--- a/src/example/nestedRulesSample-fluent.ts
+++ b/src/example/nestedRulesSample-fluent.ts
@@ -15,12 +15,12 @@ let data = {
 const validator = validatorBuilder()
   .newRule()
   .withField('platform')
-  .validate(RuleBuilder.isIn.withValues('MOBILE', 'DESKTOP'))
+  .validate(RuleBuilder.isIn.withValues('MOBILE', 'DESKTOP').build())
   .validate(RuleBuilder.required())
   .newRule()
   .withFieldValueConstraint('platform', 'mobile')
   .withField('os')
-  .validate(RuleBuilder.isIn.withValues('ANDROID', 'iOS', 'WINDOWS'))
+  .validate(RuleBuilder.isIn.withValues('ANDROID', 'iOS', 'WINDOWS').build())
   .validate(RuleBuilder.required())
   .withField('programming_lang')
   .validate(
@@ -30,21 +30,23 @@ const validator = validatorBuilder()
         RuleBuilder.composite
           .all()
           .withSubRule(RuleBuilder.exactValue.withPathAndValue('os', 'ANDROID'))
-          .withSubRule(RuleBuilder.isIn.withValues('JAVA', 'KOTLIN'))
+          .withSubRule(RuleBuilder.isIn.withValues('JAVA', 'KOTLIN').build())
           .build()
       )
       .withSubRule(
         RuleBuilder.composite
           .all()
           .withSubRule(RuleBuilder.exactValue.withPathAndValue('os', 'iOS'))
-          .withSubRule(RuleBuilder.isIn.withValues('SWIFT', 'OBJECTIVE-C'))
+          .withSubRule(
+            RuleBuilder.isIn.withValues('SWIFT', 'OBJECTIVE-C').build()
+          )
           .build()
       )
       .withSubRule(
         RuleBuilder.composite
           .all()
           .withSubRule(RuleBuilder.exactValue.withPathAndValue('os', 'WINDOWS'))
-          .withSubRule(RuleBuilder.isIn.withValues('C#'))
+          .withSubRule(RuleBuilder.isIn.withValues('C#').build())
           .build()
       )
       .build()
@@ -52,7 +54,7 @@ const validator = validatorBuilder()
   .newRule()
   .withFieldValueConstraint('platform', 'DESKTOP')
   .withField('os')
-  .validate(RuleBuilder.isIn.withValues('WINDOWS', 'LINUX'))
+  .validate(RuleBuilder.isIn.withValues('WINDOWS', 'LINUX').build())
   .withField('programming_lang')
   .validate(
     RuleBuilder.composite
@@ -61,14 +63,16 @@ const validator = validatorBuilder()
         RuleBuilder.composite
           .all()
           .withSubRule(RuleBuilder.exactValue.withPathAndValue('os', 'WINDOWS'))
-          .withSubRule(RuleBuilder.isIn.withValues('JAVA', 'C/C++', 'C#'))
+          .withSubRule(
+            RuleBuilder.isIn.withValues('JAVA', 'C/C++', 'C#').build()
+          )
           .build()
       )
       .withSubRule(
         RuleBuilder.composite
           .all()
           .withSubRule(RuleBuilder.exactValue.withPathAndValue('os', 'LINUX'))
-          .withSubRule(RuleBuilder.isIn.withValues('JAVA', 'C/C++'))
+          .withSubRule(RuleBuilder.isIn.withValues('JAVA', 'C/C++').build())
           .build()
       )
       .build()

--- a/src/rules/builders/CompositeRuleBuilder.ts
+++ b/src/rules/builders/CompositeRuleBuilder.ts
@@ -20,9 +20,10 @@ export const builder = {
       return {withSubRule, build};
     };
 
-    const build = (): RuleConfig => ({
+    const build = (errorMessage?: string): RuleConfig => ({
       type: 'COMPOSITE',
       algorithm: 'any',
+      errorMessage,
       subRules,
     });
 
@@ -38,9 +39,10 @@ export const builder = {
       return {withSubRule, build};
     };
 
-    const build = (): RuleConfig => ({
+    const build = (errorMessage?: string): RuleConfig => ({
       type: 'COMPOSITE',
       algorithm: 'all',
+      errorMessage,
       subRules,
     });
 

--- a/src/rules/builders/ExactValueBuilder.ts
+++ b/src/rules/builders/ExactValueBuilder.ts
@@ -1,13 +1,19 @@
 import {RuleConfig} from '../../config/RuleConfig';
 
 export const builder = {
-  withValue: (value: string | number): RuleConfig => ({
+  withValue: (value: string | number, errorMessage?: string): RuleConfig => ({
     type: 'EXACT_VALUE',
     value,
+    errorMessage,
   }),
-  withPathAndValue: (path: string, value: string | number): RuleConfig => ({
+  withPathAndValue: (
+    path: string,
+    value: string | number,
+    errorMessage?: string
+  ): RuleConfig => ({
     type: 'EXACT_VALUE',
     path,
     value,
+    errorMessage,
   }),
 };

--- a/src/rules/builders/IsInBuilder.ts
+++ b/src/rules/builders/IsInBuilder.ts
@@ -1,8 +1,84 @@
 import {RuleConfig} from '../../config/RuleConfig';
 
-export const builder = {
-  withValues: (...values: string[]): RuleConfig => ({
-    type: 'isIn',
-    values: values.join(),
-  }),
+export interface IsInBuilderInterface {
+  withValues(...values: string[]): IsInBuilderFinalInterface;
+  withValue(value: string): IsInBuilderFinalInterface;
+}
+
+export interface IsInBuilderFinalInterface {
+  withValues(...values: string[]): IsInBuilderFinalInterface;
+  withValue(value: string): IsInBuilderFinalInterface;
+  build(errorMessage?: string): RuleConfig;
+}
+
+function createWithValueFunction(
+  rule: RuleConfig
+): (value: string) => IsInBuilderFinalInterface {
+  const withValue = (value: string): IsInBuilderFinalInterface => {
+    (rule.values as string[]).push(value);
+
+    return {
+      withValues: createWithValuesFunction(rule),
+      withValue: createWithValueFunction(rule),
+      build: createBuildFunction(rule),
+    };
+  };
+  return withValue;
+}
+
+function createWithValuesFunction(
+  rule: RuleConfig
+): (value: string) => IsInBuilderFinalInterface {
+  const withValues = (...values: string[]): IsInBuilderFinalInterface => {
+    (rule.values as string[]) = [...(rule.values as string[]), ...values];
+
+    return {
+      withValues: createWithValuesFunction(rule),
+      withValue: createWithValueFunction(rule),
+      build: createBuildFunction(rule),
+    };
+  };
+
+  return withValues;
+}
+
+function createBuildFunction(
+  rule: RuleConfig
+): (errorMessage: string) => RuleConfig {
+  const build = (errorMessage?: string) => {
+    return {
+      type: rule.type,
+      values: (rule.values as string[]).join(),
+      errorMessage,
+    };
+  };
+
+  return build;
+}
+
+export const builder: IsInBuilderInterface = {
+  withValues: (...values: string[]): IsInBuilderFinalInterface => {
+    const rule: RuleConfig = {
+      type: 'isIn',
+      values: values || [],
+    };
+
+    return {
+      withValues: createWithValuesFunction(rule),
+      withValue: createWithValueFunction(rule),
+      build: createBuildFunction(rule),
+    };
+  },
+  withValue: (value: string): IsInBuilderFinalInterface => {
+    const rule: RuleConfig = {
+      type: 'isIn',
+      values: [value],
+    };
+
+    return {
+      withValues: createWithValuesFunction(rule),
+      withValue: createWithValueFunction(rule),
+      build: createBuildFunction(rule),
+    };
+  },
 };

--- a/src/rules/builders/LengthRuleBuilder.ts
+++ b/src/rules/builders/LengthRuleBuilder.ts
@@ -2,5 +2,9 @@ import * as LengthRule from '../LengthRule';
 import {RuleConfig} from '../../config/RuleConfig';
 
 export const builder = {
-  withLength: (length: number): RuleConfig => ({type: LengthRule.NAME, length}),
+  withLength: (length: number, errorMessage?: string): RuleConfig => ({
+    type: LengthRule.NAME,
+    length,
+    errorMessage,
+  }),
 };

--- a/src/rules/builders/MatchesRuleBuilder.ts
+++ b/src/rules/builders/MatchesRuleBuilder.ts
@@ -1,5 +1,9 @@
 import {RuleConfig} from '../../config/RuleConfig';
 
 export const builder = {
-  withPattern: (pattern: string): RuleConfig => ({type: 'matches', pattern}),
+  withPattern: (pattern: string, errorMessage?: string): RuleConfig => ({
+    type: 'matches',
+    pattern,
+    errorMessage,
+  }),
 };

--- a/src/rules/builders/RequiredValueBuilder.ts
+++ b/src/rules/builders/RequiredValueBuilder.ts
@@ -1,8 +1,9 @@
 import {RuleConfig} from '../../config/RuleConfig';
 
 export const builder = {
-  required: (path?: string): RuleConfig => ({
+  required: (path?: string, errorMessage?: string): RuleConfig => ({
     type: 'REQUIRED',
     path,
+    errorMessage,
   }),
 };


### PR DESCRIPTION
The builders didn't allow to specify custom error message, while such
ability was present into the JSON config file.

**BREAKING CHANGE**: Now the isIn rule builder requires the build method to
be called